### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :move_to_index, only: [:edit, :update]
 
   def index
@@ -11,6 +11,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path, notice: '商品を削除しました'
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% unless @item.sold_out? %>
     <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#" , data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item) , data: {turbo_method: :delete}, class:"item-destroy" %>
   <% end %>
 <% else%>
   <% unless @item.sold_out? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:new, :create, :show, :edit, :update] 
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy] 
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
# What
商品削除機能の実装: ログイン中の出品者本人のみが、出品した商品を削除できる機能を実装しました。

コントローラーとルーティング: ItemsControllerにdestroyアクションを定義し、ルーティングも追加しました。

削除ボタンの実装: 商品詳細画面に削除ボタンを実装し、DELETEリクエストを送信できるようにしました。

アクセス制御: ログイン中の出品者本人のみが削除ボタンを表示・実行できるようにしました。

リファクタリング: @item = Item.find(params[:id])の記述をset_itemメソッドに切り出し、before_actionで呼び出すように修正しました。

# Why
ユーザー管理の強化:

出品者が不要になった商品を自分で削除できるようにすることで、サービスの利便性を向上させました。

出品者本人以外は商品を削除できないように制御し、データの安全性を確保しました。

コードの改善:

重複していたコードをset_itemというプライベートメソッドにまとめることで、コードの可読性と保守性を高めました。これにより、今後の修正や機能追加が容易になります。

データの整合性確保:

商品が削除された後に、トップページにリダイレクトすることで、ユーザーに削除が成功したことを伝えます。